### PR TITLE
Correct owner team

### DIFF
--- a/Repofile
+++ b/Repofile
@@ -4,7 +4,7 @@
         "Test Integration"
     ],
     "maintainers": [
-        "cash-payments"
+        "cash-data"
     ],
     "topics": [
         "github-action",

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: other
   lifecycle: experimental
-  owner: cash-payments
+  owner: cash-data


### PR DESCRIPTION
"cash-payments" do not have an entry in the [teams.csv](https://github.com/Tradeshift/teams/blob/master/teams.csv) file. Thus, this PR changes the owner of the repo from "cash-payments" to "cash-platform"